### PR TITLE
Attempt to get gfortran builds working on windows

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1,5 +1,16 @@
 import os
+import sys
+
+env = DefaultEnvironment()
+
+# SCons configures gfortran by default, tell it where it is.
+if sys.platform == "win32":
+    env.PrependENVPath(
+        "PATH", os.path.join("C:", os.path.sep, "ANSYSDev", "MinGW", "bin")
+    )
+
+env.Export("env")
 
 module_name = "TestSConscript"
 sconscript = os.path.join(module_name, "SConscript")
-SConscript(sconscript)
+env.SConscript(sconscript)

--- a/SConstruct2
+++ b/SConstruct2
@@ -1,6 +1,16 @@
 import os
+import sys
+
+env = DefaultEnvironment()
+
+# SCons configures gfortran by default, tell it where it is.
+if sys.platform == "win32":
+    env.PrependENVPath(
+        "PATH", os.path.join("C:", os.path.sep, "ANSYSDev", "MinGW", "bin")
+    )
+
+env.Export("env")
 
 module_name = "TestSConscript"
 sconscript = os.path.join(module_name, "SConscript_gfortran2")
-SConscript(sconscript)
-
+env.SConscript(sconscript)

--- a/SConstruct3
+++ b/SConstruct3
@@ -1,5 +1,16 @@
 import os
+import sys
+
+env = DefaultEnvironment()
+
+# SCons configures gfortran by default, tell it where it is.
+if sys.platform == "win32":
+    env.PrependENVPath(
+        "PATH", os.path.join("C:", os.path.sep, "ANSYSDev", "MinGW", "bin")
+    )
+
+env.Export("env")
 
 module_name = "TestSConscript"
 sconscript = os.path.join(module_name, "SConscript_gfortran3")
-SConscript(sconscript)
+env.SConscript(sconscript)

--- a/SConstructVariant
+++ b/SConstructVariant
@@ -1,15 +1,25 @@
 import os
 import sys
 
+env = DefaultEnvironment()
+
+# SCons configures gfortran by default, tell it where it is.
+if sys.platform == "win32":
+    env.PrependENVPath(
+        "PATH", os.path.join("C:", os.path.sep, "ANSYSDev", "MinGW", "bin")
+    )
+
+env.Export("env")
+
 module_name = "TestSConscript"
 build_dir = os.path.join(module_name, "builds1", sys.platform)
 sconscript = os.path.join(module_name, "SConscript")
-SConscript(sconscript, variant_dir=build_dir)
+env.SConscript(sconscript, variant_dir=build_dir)
 
 build_dir = os.path.join(module_name, "builds2", sys.platform)
 sconscript = os.path.join(module_name, "SConscript_gfortran2")
-SConscript(sconscript, variant_dir=build_dir)
+env.SConscript(sconscript, variant_dir=build_dir)
 
 build_dir = os.path.join(module_name, "builds3", sys.platform)
 sconscript = os.path.join(module_name, "SConscript_gfortran3")
-SConscript(sconscript, variant_dir=build_dir)
+env.SConscript(sconscript, variant_dir=build_dir)

--- a/SConstructVariant2
+++ b/SConstructVariant2
@@ -2,6 +2,16 @@
 import os
 import sys
 
+env = DefaultEnvironment()
+
+# SCons configures gfortran by default, tell it where it is.
+if sys.platform == "win32":
+    env.PrependENVPath(
+        "PATH", os.path.join("C:", os.path.sep, "ANSYSDev", "MinGW", "bin")
+    )
+
+env.Export("env")
+
 module_name = "TestSConscript"
 build_dir = os.path.join(module_name, "builds12", sys.platform)
 sconscript = os.path.join(module_name, "SConscript")

--- a/TestFlat/SConstruct
+++ b/TestFlat/SConstruct
@@ -1,4 +1,15 @@
-f90_sources = Glob('*.f90')
-for_sources = Glob('*.f')
+import os
+import sys
+
+env = DefaultEnvironment()
+
+# SCons configures gfortran by default, tell it where it is.
+if sys.platform == "win32":
+    env.PrependENVPath(
+        "PATH", os.path.join("C:", os.path.sep, "ANSYSDev", "MinGW", "bin")
+    )
+
+f90_sources = Glob("*.f90")
+for_sources = Glob("*.f")
 all_sources = f90_sources + for_sources
-Program(target='main_prog.exe', source=all_sources)
+env.Program(target="main_prog.exe", source=all_sources)

--- a/TestFlat/SConstruct_gfortran2
+++ b/TestFlat/SConstruct_gfortran2
@@ -1,5 +1,15 @@
+import os
+import sys
+
 tool_list = ["default", "gfortran"]
 env = Environment(tools = tool_list)
+
+# SCons configures gfortran by default, tell it where it is.
+if sys.platform == "win32":
+    env.PrependENVPath(
+        "PATH", os.path.join("C:", os.path.sep, "ANSYSDev", "MinGW", "bin")
+    )
+
 f90_sources = Glob('*.f90')
 for_sources = Glob('*.f')
 all_sources = f90_sources + for_sources

--- a/TestFlat/SConstruct_gfortran3
+++ b/TestFlat/SConstruct_gfortran3
@@ -1,4 +1,15 @@
 # Tests if the Program target is robust to reorder of the source files
+import os
+import sys
+
+env = DefaultEnvironment()
+
+# SCons configures gfortran by default, tell it where it is.
+if sys.platform == "win32":
+    env.PrependENVPath(
+        "PATH", os.path.join("C:", os.path.sep, "ANSYSDev", "MinGW", "bin")
+    )
+
 f90_sources = Glob('*.f90')
 for_sources = Glob('*.f')
 all_sources = for_sources + f90_sources

--- a/TestSConscript/SConscript
+++ b/TestSConscript/SConscript
@@ -1,4 +1,6 @@
-f90_sources = Glob('*.f90')
-for_sources = Glob('*.f')
+Import("env")
+
+f90_sources = env.Glob('*.f90')
+for_sources = env.Glob('*.f')
 all_sources = f90_sources + for_sources
-Program(target='main_prog.exe', source=all_sources)
+env.Program(target='main_prog.exe', source=all_sources)

--- a/TestSConscript/SConscript_gfortran2
+++ b/TestSConscript/SConscript_gfortran2
@@ -1,6 +1,6 @@
-tool_list = ["default", "gfortran"]
-env = Environment(tools = tool_list)
-f90_sources = Glob('*.f90')
-for_sources = Glob('*.f')
+Import("env")
+
+f90_sources = env.Glob('*.f90')
+for_sources = env.Glob('*.f')
 all_sources = f90_sources + for_sources
 env.Program(target='main_prog.exe', source=all_sources)

--- a/TestSConscript/SConscript_gfortran3
+++ b/TestSConscript/SConscript_gfortran3
@@ -1,4 +1,6 @@
-f90_sources = Glob('*.f90')
-for_sources = Glob('*.f')
+Import("env")
+
+f90_sources = env.Glob('*.f90')
+for_sources = env.Glob('*.f')
 all_sources = for_sources + f90_sources
-Program(target='main_prog.exe', source=all_sources)
+env.Program(target='main_prog.exe', source=all_sources)


### PR DESCRIPTION
It seems SCons configures gfortran by default, but on Windows this may be a somewhat arbitrary location, so it's not found unless you prepend the location to the environment path.  With these changes it now finds gfortran installed on windows.

Unfortunately all the final Program builds are still not working because the default linker is the msvc linker and it does not find the fortran runtimes (they are not passed automatically by SCons based on the compilers location).  Build output is as follows:

```
scons: Reading SConscript files ...
scons: done reading SConscript files.
scons: Building targets ...
gfortran -o TestSConscript\builds1\win32\module_two.obj -c TestSConscript\builds1\win32\module_two.f90
gfortran -o TestSConscript\builds1\win32\module_one.obj -c TestSConscript\builds1\win32\module_one.f90
gfortran -o TestSConscript\builds1\win32\main_prog.obj -c TestSConscript\builds1\win32\main_prog.f
link /nologo /OUT:TestSConscript\builds1\win32\main_prog.exe TestSConscript\builds1\win32\module_one.obj TestSConscript\builds1\win32\module_two.obj TestSConscript\builds1\win32\main_prog.obj
module_one.obj : error LNK2019: unresolved external symbol __gfortran_st_write referenced in function ___module_one_MOD_telltwosayhello
module_two.obj : error LNK2001: unresolved external symbol __gfortran_st_write
module_one.obj : error LNK2019: unresolved external symbol __gfortran_transfer_character_write referenced in function ___module_one_MOD_telltwosayhello
module_two.obj : error LNK2001: unresolved external symbol __gfortran_transfer_character_write
module_one.obj : error LNK2019: unresolved external symbol __gfortran_st_write_done referenced in function ___module_one_MOD_telltwosayhello
module_two.obj : error LNK2001: unresolved external symbol __gfortran_st_write_done
main_prog.obj : error LNK2019: unresolved external symbol ___main referenced in function _main
main_prog.obj : error LNK2019: unresolved external symbol __gfortran_set_args referenced in function _main
main_prog.obj : error LNK2019: unresolved external symbol __gfortran_set_options referenced in function _main
LINK : error LNK2001: unresolved external symbol _mainCRTStartup
TestSConscript\builds1\win32\main_prog.exe : fatal error LNK1120: 7 unresolved externals
scons: *** [TestSConscript\builds1\win32\main_prog.exe] Error 1120
scons: building terminated because of errors.

```