### PR TITLE
Custom gfortran install needs right path

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -8,6 +8,8 @@ if sys.platform == "win32":
     env.PrependENVPath(
         "PATH", os.path.join("C:", os.path.sep, "ANSYSDev", "MinGW", "bin")
     )
+elif sys.platform == "linux":
+    env.PrependENVPath("PATH", os.path.join(os.path.sep, "opt", "anss", "bin"))
 
 env.Export("env")
 

--- a/SConstruct2
+++ b/SConstruct2
@@ -8,6 +8,8 @@ if sys.platform == "win32":
     env.PrependENVPath(
         "PATH", os.path.join("C:", os.path.sep, "ANSYSDev", "MinGW", "bin")
     )
+elif sys.platform == "linux":
+    env.PrependENVPath("PATH", os.path.join(os.path.sep, "opt", "anss", "bin"))
 
 env.Export("env")
 

--- a/SConstruct3
+++ b/SConstruct3
@@ -8,6 +8,8 @@ if sys.platform == "win32":
     env.PrependENVPath(
         "PATH", os.path.join("C:", os.path.sep, "ANSYSDev", "MinGW", "bin")
     )
+elif sys.platform == "linux":
+    env.PrependENVPath("PATH", os.path.join(os.path.sep, "opt", "anss", "bin"))
 
 env.Export("env")
 

--- a/SConstructVariant
+++ b/SConstructVariant
@@ -8,6 +8,8 @@ if sys.platform == "win32":
     env.PrependENVPath(
         "PATH", os.path.join("C:", os.path.sep, "ANSYSDev", "MinGW", "bin")
     )
+elif sys.platform == "linux":
+    env.PrependENVPath("PATH", os.path.join(os.path.sep, "opt", "anss", "bin"))
 
 env.Export("env")
 

--- a/SConstructVariant2
+++ b/SConstructVariant2
@@ -9,6 +9,8 @@ if sys.platform == "win32":
     env.PrependENVPath(
         "PATH", os.path.join("C:", os.path.sep, "ANSYSDev", "MinGW", "bin")
     )
+elif sys.platform == "linux":
+    env.PrependENVPath("PATH", os.path.join(os.path.sep, "opt", "anss", "bin"))
 
 env.Export("env")
 

--- a/TestFlat/SConstruct
+++ b/TestFlat/SConstruct
@@ -8,6 +8,8 @@ if sys.platform == "win32":
     env.PrependENVPath(
         "PATH", os.path.join("C:", os.path.sep, "ANSYSDev", "MinGW", "bin")
     )
+elif sys.platform == "linux":
+    env.PrependENVPath("PATH", os.path.join(os.path.sep, "opt", "anss", "bin"))
 
 f90_sources = Glob("*.f90")
 for_sources = Glob("*.f")

--- a/TestFlat/SConstruct_gfortran2
+++ b/TestFlat/SConstruct_gfortran2
@@ -9,6 +9,8 @@ if sys.platform == "win32":
     env.PrependENVPath(
         "PATH", os.path.join("C:", os.path.sep, "ANSYSDev", "MinGW", "bin")
     )
+elif sys.platform == "linux":
+    env.PrependENVPath("PATH", os.path.join(os.path.sep, "opt", "anss", "bin"))
 
 f90_sources = Glob('*.f90')
 for_sources = Glob('*.f')

--- a/TestFlat/SConstruct_gfortran3
+++ b/TestFlat/SConstruct_gfortran3
@@ -9,6 +9,8 @@ if sys.platform == "win32":
     env.PrependENVPath(
         "PATH", os.path.join("C:", os.path.sep, "ANSYSDev", "MinGW", "bin")
     )
+elif sys.platform == "linux":
+    env.PrependENVPath("PATH", os.path.join(os.path.sep, "opt", "anss", "bin"))
 
 f90_sources = Glob('*.f90')
 for_sources = Glob('*.f')


### PR DESCRIPTION
If gfortran is not in the standard location you need to prepend the environment path.